### PR TITLE
Expect an empty backup list on non-existing volume

### DIFF
--- a/pkg/sanity/cloudbackup.go
+++ b/pkg/sanity/cloudbackup.go
@@ -359,7 +359,6 @@ var _ = Describe("Cloud backup [OpenStorageCluster]", func() {
 				enumerateResp, err := bc.Enumerate(
 					context.Background(),
 					&api.SdkCloudBackupEnumerateRequest{
-						All:          true,
 						ClusterId:    clusterID,
 						CredentialId: credID,
 						SrcVolumeId:  volID,
@@ -393,8 +392,9 @@ var _ = Describe("Cloud backup [OpenStorageCluster]", func() {
 					CredentialId: credID,
 				}
 
-				_, err := bc.Enumerate(context.Background(), enumerateReq)
-				Expect(err).To(HaveOccurred())
+				resp, err := bc.Enumerate(context.Background(), enumerateReq)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.GetBackups()).To(BeEmpty())
 			}
 		})
 


### PR DESCRIPTION
The volume could have been deleted so the expectation is that
a non-existing volume may or may not return a populated list.

Requires https://github.com/libopenstorage/openstorage/pull/604

Signed-off-by: Luis Pabón <luis@portworx.com>